### PR TITLE
Fix get issue timings

### DIFF
--- a/lib/jira.ts
+++ b/lib/jira.ts
@@ -124,7 +124,11 @@ export class Jira {
 
             const newStatusIsFinalStatus = finalStatuses.indexOf(newStatus) >= 0;
             const prevStatusIsFinalStatus = finalStatuses.indexOf(prevStatus) >= 0;
-            if (newStatusIsFinalStatus && !prevStatusIsFinalStatus) doneTime = newStatusStartTime;
+            if (newStatusIsFinalStatus && !prevStatusIsFinalStatus) {
+                doneTime = newStatusStartTime;
+            } else if (prevStatusIsFinalStatus && !newStatusIsFinalStatus) {
+                doneTime = null;
+            }
 
             prevStatus = newStatus;
             prevStatusStartTime = newStatusStartTime;

--- a/lib/jira.ts
+++ b/lib/jira.ts
@@ -122,10 +122,12 @@ export class Jira {
             if (!timeInStatuses[prevStatus]) timeInStatuses[prevStatus] = 0;
             timeInStatuses[prevStatus] += secondsInPreviousStatus;
 
+            const newStatusIsFinalStatus = finalStatuses.indexOf(newStatus) >= 0;
+            const prevStatusIsFinalStatus = finalStatuses.indexOf(prevStatus) >= 0;
+            if (newStatusIsFinalStatus && !prevStatusIsFinalStatus) doneTime = newStatusStartTime;
+
             prevStatus = newStatus;
             prevStatusStartTime = newStatusStartTime;
-
-            if (finalStatuses.indexOf(newStatus) >= 0) doneTime = newStatusStartTime;
         });
 
         const secondsInPreviousStatus = new Date().getTime() - prevStatusStartTime.getTime();

--- a/scripts/storypoints.ts
+++ b/scripts/storypoints.ts
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import { Jira } from "../lib/jira";
-import { Issue, Config, Argv, Script } from "../lib/interfaces";
+import { Issue, Config, Argv, Script, IssueTimings } from "../lib/interfaces";
 import * as fs from "fs";
 import dateformat from "dateformat";
 import jiraConfig from "../config.jira.json";
@@ -58,7 +58,7 @@ const script: Script = async (config: Config, argv: Argv) => {
 
     const issueTimings = issuesWithStoryPoints.map(issue => Jira.getIssueTimings(issue, FINAL_STATUS_NAMES));
 
-    const storyPointsObj = {};
+    const storyPointsObj: { [storyPoints: string]: IssueTimings[] } = {};
 
     issueTimings.forEach(issueTiming => {
         const issue = issuesWithStoryPointsMap.get(issueTiming.key);

--- a/tests/ABC-1.json
+++ b/tests/ABC-1.json
@@ -1,5 +1,8 @@
 {
     "$schema": "./_issue.schema.json",
+    "fields": {
+        "summary": "Test issue"
+    },
     "changelog": {
         "histories": [
             {

--- a/tests/jira.spec.ts
+++ b/tests/jira.spec.ts
@@ -317,6 +317,48 @@ describe("Jira", () => {
                 expect(timings.finished).not.to.be.null;
                 expect(timings.finished.getFullYear()).to.equal(2018);
             });
+
+            it("should be the first one of many concurrent, same, finishing statuses", () => {
+                const FINISH_STATE = "finish";
+                exampleIssue.changelog.histories[0].items = [statusHistoryItem({ toString: FINISH_STATE })];
+                exampleIssue.changelog.histories[0].created = "2018-01-01";
+                exampleIssue.changelog.histories[1].items = [statusHistoryItem({ toString: FINISH_STATE })];
+                exampleIssue.changelog.histories[1].created = "2018-01-02";
+
+                const timings = Jira.getIssueTimings(exampleIssue, [FINISH_STATE]);
+
+                expect(timings.finished).not.to.be.null;
+                expect(timings.finished.getFullYear()).to.equal(2018);
+                expect(timings.finished.getDate()).to.equal(1);
+            });
+
+            it("should be the first one of many concurrent, different, finishing statuses", () => {
+                const FINISH_STATE1 = "finish1";
+                const FINISH_STATE2 = "finish2";
+                exampleIssue.changelog.histories[0].items = [statusHistoryItem({ toString: FINISH_STATE1 })];
+                exampleIssue.changelog.histories[0].created = "2018-01-01";
+                exampleIssue.changelog.histories[1].items = [statusHistoryItem({ toString: FINISH_STATE2 })];
+                exampleIssue.changelog.histories[1].created = "2018-01-02";
+
+                const timings = Jira.getIssueTimings(exampleIssue, [FINISH_STATE1, FINISH_STATE2]);
+
+                expect(timings.finished).not.to.be.null;
+                expect(timings.finished.getFullYear()).to.equal(2018);
+                expect(timings.finished.getDate()).to.equal(1);
+            });
+
+            it("should be null if the issue has become un-finished", () => {
+                const FINISH_STATE = "finish";
+                const NOT_FINISH_STATE = "foo";
+                exampleIssue.changelog.histories[0].items = [statusHistoryItem({ toString: FINISH_STATE })];
+                exampleIssue.changelog.histories[0].created = "2018-01-01";
+                exampleIssue.changelog.histories[1].items = [statusHistoryItem({ toString: NOT_FINISH_STATE })];
+                exampleIssue.changelog.histories[1].created = "2018-01-02";
+
+                const timings = Jira.getIssueTimings(exampleIssue, [FINISH_STATE]);
+
+                expect(timings.finished).to.be.null;
+            });
         });
     });
 });

--- a/tests/jira.spec.ts
+++ b/tests/jira.spec.ts
@@ -37,8 +37,15 @@ function historyItem(partial: any): HistoryItem {
     return Object.assign(historyItem, partial);
 }
 
-function statusHistoryItem(partial: any): HistoryItem {
-    const statusHistoryItem = { field: "status", fieldtype: "jira" };
+function statusHistoryItem(partial: any = {}): HistoryItem {
+    const statusHistoryItem = {
+        field: "status",
+        fieldtype: "jira",
+        from: "1",
+        to: "2",
+        fromString: "a",
+        toString: "b"
+    };
     return historyItem(Object.assign(statusHistoryItem, partial));
 }
 
@@ -289,6 +296,27 @@ describe("Jira", () => {
                     `updatedDate >= 2018-01-01 and ` +
                     `updatedDate <= 2018-01-02`
             );
+        });
+    });
+
+    describe("getIssueTimings", () => {
+        describe("property: finished", () => {
+            it("should not be defined if the issue has not finished", () => {
+                exampleIssue.changelog.histories[0].items = [statusHistoryItem()];
+                const timings = Jira.getIssueTimings(exampleIssue, []);
+                expect(timings.finished).to.be.null;
+            });
+
+            it("should be found from a single finishing status change", () => {
+                const FINISH_STATE = "finish";
+                exampleIssue.changelog.histories[0].items = [statusHistoryItem({ toString: FINISH_STATE })];
+                exampleIssue.changelog.histories[0].created = "2018-01-01";
+
+                const timings = Jira.getIssueTimings(exampleIssue, [FINISH_STATE]);
+
+                expect(timings.finished).not.to.be.null;
+                expect(timings.finished.getFullYear()).to.equal(2018);
+            });
         });
     });
 });

--- a/tests/jira.spec.ts
+++ b/tests/jira.spec.ts
@@ -301,31 +301,36 @@ describe("Jira", () => {
 
     describe("getIssueTimings", () => {
         describe("property: finished", () => {
-            it("should not be defined if the issue has not finished", () => {
+            it("should be null if the issue has not finished", () => {
                 exampleIssue.changelog.histories[0].items = [statusHistoryItem()];
                 const timings = Jira.getIssueTimings(exampleIssue, []);
                 expect(timings.finished).to.be.null;
             });
 
             it("should be found from a single finishing status change", () => {
-                const FINISH_STATE = "finish";
-                exampleIssue.changelog.histories[0].items = [statusHistoryItem({ toString: FINISH_STATE })];
+                const FINAL_STATUS = "finish";
+                exampleIssue.changelog.histories[0].items = [statusHistoryItem({ toString: FINAL_STATUS })];
                 exampleIssue.changelog.histories[0].created = "2018-01-01";
 
-                const timings = Jira.getIssueTimings(exampleIssue, [FINISH_STATE]);
+                const timings = Jira.getIssueTimings(exampleIssue, [FINAL_STATUS]);
 
                 expect(timings.finished).not.to.be.null;
                 expect(timings.finished.getFullYear()).to.equal(2018);
             });
 
             it("should be the first one of many concurrent, same, finishing statuses", () => {
-                const FINISH_STATE = "finish";
-                exampleIssue.changelog.histories[0].items = [statusHistoryItem({ toString: FINISH_STATE })];
+                const FINAL_STATUS = "finish";
+                exampleIssue.changelog.histories[0].items = [statusHistoryItem({ toString: FINAL_STATUS })];
                 exampleIssue.changelog.histories[0].created = "2018-01-01";
-                exampleIssue.changelog.histories[1].items = [statusHistoryItem({ toString: FINISH_STATE })];
+                exampleIssue.changelog.histories[1].items = [
+                    statusHistoryItem({
+                        fromString: FINAL_STATUS,
+                        toString: FINAL_STATUS
+                    })
+                ];
                 exampleIssue.changelog.histories[1].created = "2018-01-02";
 
-                const timings = Jira.getIssueTimings(exampleIssue, [FINISH_STATE]);
+                const timings = Jira.getIssueTimings(exampleIssue, [FINAL_STATUS]);
 
                 expect(timings.finished).not.to.be.null;
                 expect(timings.finished.getFullYear()).to.equal(2018);
@@ -333,14 +338,19 @@ describe("Jira", () => {
             });
 
             it("should be the first one of many concurrent, different, finishing statuses", () => {
-                const FINISH_STATE1 = "finish1";
-                const FINISH_STATE2 = "finish2";
-                exampleIssue.changelog.histories[0].items = [statusHistoryItem({ toString: FINISH_STATE1 })];
+                const FINAL_STATUS1 = "finish1";
+                const FINAL_STATUS2 = "finish2";
+                exampleIssue.changelog.histories[0].items = [statusHistoryItem({ toString: FINAL_STATUS1 })];
                 exampleIssue.changelog.histories[0].created = "2018-01-01";
-                exampleIssue.changelog.histories[1].items = [statusHistoryItem({ toString: FINISH_STATE2 })];
+                exampleIssue.changelog.histories[1].items = [
+                    statusHistoryItem({
+                        fromString: FINAL_STATUS1,
+                        toString: FINAL_STATUS2
+                    })
+                ];
                 exampleIssue.changelog.histories[1].created = "2018-01-02";
 
-                const timings = Jira.getIssueTimings(exampleIssue, [FINISH_STATE1, FINISH_STATE2]);
+                const timings = Jira.getIssueTimings(exampleIssue, [FINAL_STATUS1, FINAL_STATUS2]);
 
                 expect(timings.finished).not.to.be.null;
                 expect(timings.finished.getFullYear()).to.equal(2018);
@@ -348,14 +358,14 @@ describe("Jira", () => {
             });
 
             it("should be null if the issue has become un-finished", () => {
-                const FINISH_STATE = "finish";
-                const NOT_FINISH_STATE = "foo";
-                exampleIssue.changelog.histories[0].items = [statusHistoryItem({ toString: FINISH_STATE })];
+                const FINAL_STATUS = "finish";
+                const NOT_FINAL_STATUS = "foo";
+                exampleIssue.changelog.histories[0].items = [statusHistoryItem({ toString: FINAL_STATUS })];
                 exampleIssue.changelog.histories[0].created = "2018-01-01";
-                exampleIssue.changelog.histories[1].items = [statusHistoryItem({ toString: NOT_FINISH_STATE })];
+                exampleIssue.changelog.histories[1].items = [statusHistoryItem({ toString: NOT_FINAL_STATUS })];
                 exampleIssue.changelog.histories[1].created = "2018-01-02";
 
-                const timings = Jira.getIssueTimings(exampleIssue, [FINISH_STATE]);
+                const timings = Jira.getIssueTimings(exampleIssue, [FINAL_STATUS]);
 
                 expect(timings.finished).to.be.null;
             });

--- a/tests/jira.spec.ts
+++ b/tests/jira.spec.ts
@@ -45,7 +45,7 @@ function statusHistoryItem(partial: any): HistoryItem {
 describe("Jira", () => {
     let exampleIssue: Issue & HasChangelog = null;
     beforeEach(async () => {
-        exampleIssue = <any>await import("./ABC-1.json");
+        exampleIssue = <any>JSON.parse(JSON.stringify(await import("./ABC-1.json")));
     });
 
     describe("getIssueStatusEvents", () => {


### PR DESCRIPTION
There were some issues with how the "finished" timings were handled with transitions:

1. The status was not reset when an issue transitioned out of the status, 
2. The "finished time" was always blindly taken from the last finished timing, even if there would be transitions from a finished state to another (or same) finished state.

Fixes #14